### PR TITLE
Fix crash of statically linked Linux binaries.

### DIFF
--- a/src/emu/processor-impl.h
+++ b/src/emu/processor-impl.h
@@ -179,6 +179,9 @@ namespace riscv {
 				P::ireg[i].r.xu.val = *(u64*)(random + (rand_bytes & (SHA512_OUTPUT_BYTES - 1)));
 				rand_bytes += 8;
 			}
+
+			/* libc will register a0 into exit handler. We don't need it, so keep it as zero */
+			P::ireg[rv_ireg_a0].r.xu.val = 0;
 		}
 
 		std::string format_operands(T &dec)


### PR DESCRIPTION
Statically linked binaries will cause RV8 to crash.  I searched for the cause for a while and it turns out that the source code of the glibc port (see https://github.com/riscv/riscv-glibc/blob/riscv-glibc-2.26/sysdeps/riscv/start.S) says a0 will be registered as an exit handler (probably for vDSO cleanup, though I cannot actually find anywhere in the ABI). Setting it to zero will fix the issue.