### PR TITLE
Fix scripts in bin/

### DIFF
--- a/bin/rv-jit
+++ b/bin/rv-jit
@@ -1,6 +1,7 @@
 #!/bin/sh
+BASEDIR="$(dirname "$(dirname "$(readlink -f "$0")")")"
 OS=$(uname -s | sed 's/ /_/' | tr A-Z a-z)
 CPU=$(uname -m | sed 's/ /_/' | tr A-Z a-z)
-test "$OS" = "darwin" &&  export DYLD_LIBRARY_PATH=build/${OS}_${CPU}/lib
-test "$OS" = "linux" &&  export LD_LIBRARY_PATH=build/${OS}_${CPU}/lib
-exec build/${OS}_${CPU}/bin/rv-jit "$@"
+test "$OS" = "darwin" &&  export DYLD_LIBRARY_PATH=${BASEDIR}/build/${OS}_${CPU}/lib
+test "$OS" = "linux" &&  export LD_LIBRARY_PATH=${BASEDIR}/build/${OS}_${CPU}/lib
+exec ${BASEDIR}/build/${OS}_${CPU}/bin/rv-jit "$@"

--- a/bin/rv-jit
+++ b/bin/rv-jit
@@ -3,4 +3,4 @@ OS=$(uname -s | sed 's/ /_/' | tr A-Z a-z)
 CPU=$(uname -m | sed 's/ /_/' | tr A-Z a-z)
 test "$OS" = "darwin" &&  export DYLD_LIBRARY_PATH=build/${OS}_${CPU}/lib
 test "$OS" = "linux" &&  export LD_LIBRARY_PATH=build/${OS}_${CPU}/lib
-exec build/${OS}_${CPU}/bin/rv-jit
+exec build/${OS}_${CPU}/bin/rv-jit "$@"

--- a/bin/rv-sim
+++ b/bin/rv-sim
@@ -3,4 +3,4 @@ OS=$(uname -s | sed 's/ /_/' | tr A-Z a-z)
 CPU=$(uname -m | sed 's/ /_/' | tr A-Z a-z)
 test "$OS" = "darwin" &&  export DYLD_LIBRARY_PATH=build/${OS}_${CPU}/lib
 test "$OS" = "linux" &&  export LD_LIBRARY_PATH=build/${OS}_${CPU}/lib
-exec build/${OS}_${CPU}/bin/rv-sim
+exec build/${OS}_${CPU}/bin/rv-sim "$@"

--- a/bin/rv-sim
+++ b/bin/rv-sim
@@ -1,6 +1,7 @@
 #!/bin/sh
+BASEDIR="$(dirname "$(dirname "$(readlink -f "$0")")")"
 OS=$(uname -s | sed 's/ /_/' | tr A-Z a-z)
 CPU=$(uname -m | sed 's/ /_/' | tr A-Z a-z)
-test "$OS" = "darwin" &&  export DYLD_LIBRARY_PATH=build/${OS}_${CPU}/lib
-test "$OS" = "linux" &&  export LD_LIBRARY_PATH=build/${OS}_${CPU}/lib
-exec build/${OS}_${CPU}/bin/rv-sim "$@"
+test "$OS" = "darwin" &&  export DYLD_LIBRARY_PATH=${BASEDIR}/build/${OS}_${CPU}/lib
+test "$OS" = "linux" &&  export LD_LIBRARY_PATH=${BASEDIR}/build/${OS}_${CPU}/lib
+exec ${BASEDIR}/build/${OS}_${CPU}/bin/rv-sim "$@"


### PR DESCRIPTION
Currently the scripts are not passing the arguments to rv-jit and rv-sim, so using the programs in any meaningful way without installing it is not possible. Additionally, the use of relative paths for linking means the scripts only work when ran on the rv8 directory. The included patches add "$@" so that the arguments get to the programs, and replaces relative paths with absolute ones.