### PR TITLE
Add of the "#include <limits>" when necessary

### DIFF
--- a/src/gen/gen-cc.cc
+++ b/src/gen/gen-cc.cc
@@ -12,6 +12,7 @@
 #include <deque>
 #include <map>
 #include <set>
+#include <limits>
 
 #include "util.h"
 #include "cmdline.h"

--- a/src/gen/gen-fpu-test.cc
+++ b/src/gen/gen-fpu-test.cc
@@ -12,6 +12,7 @@
 #include <deque>
 #include <map>
 #include <set>
+#include <limits>
 
 #include "util.h"
 #include "cmdline.h"


### PR DESCRIPTION
Some compilers (such as GCC by default on Arch Linux) do not include it automatically (and others do, like on Ubuntu) so it is better to include specifically all headers needed.

Without it it does not build at all on theses systems, and the inclusion of it souldn't change anything on the others.